### PR TITLE
When there isn't a "Council Agenda" on the webpage, fails silently

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -4,6 +4,8 @@ import RetrievalManager from "./RetrievalManager";
 
 async function main() {
 	const documents = await RetrievalManager.fetchMeetingDocumentList();
+	if (documents.length === 0) return; // no documents found. preserve the previous meetings
+
 	const data = await RSSGenerator.writeFeed(documents);
 	fs.writeFile("./feeds/agenda-feed.rss", data, (err: any) => {
 		// In case of a error throw err.

--- a/src/RetrievalManager.ts
+++ b/src/RetrievalManager.ts
@@ -11,7 +11,13 @@ export default class RetrievalManager {
 	public static async fetchMeetingDocumentList(): Promise<AMSMeeting[]> {
 		const page = await OnlineRetriever.sendHTMLRequest(this.AMSAgendaLink);
 		const parser = new HTMLParser(page);
-		const allMeetings = HTMLParser.findParentTag(parser.findInnerHTML("Council Agenda"), "ul");
+		let allMeetings;
+		try {
+			allMeetings = HTMLParser.findParentTag(parser.findInnerHTML("Council Agenda"), "ul");
+		} catch (e) {
+			return []
+		}
+
 
 		return parser.parseDocumentList(allMeetings);
 	}


### PR DESCRIPTION
This may be somewhat of a short sighted change, since it also means that if the list items aren't named "Council Agenda" then it will fail silently. But this works for now to keep the blank page from throwing errors.